### PR TITLE
Update parser.h

### DIFF
--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -405,8 +405,8 @@ namespace dsmr
           // passed '3' here (which is mandatory for "mode D"
           // communication according to 62956-21), so we also allow
           // that.
-          if (line_start + 3 >= line_end || (line_start[3] != '5' && line_start[3] != '3'))
-            return res.fail("Invalid identification string", line_start);
+          //if (line_start + 3 >= line_end || (line_start[3] != '5' && line_start[3] != '3'))
+          //  return res.fail("Invalid identification string", line_start);
           // Offer it for processing using the all-ones Obis ID, which
           // is not otherwise valid.
           ParseResult<void> tmp = data->parse_line(ObisId(255, 255, 255, 255, 255, 255), line_start, line_end);


### PR DESCRIPTION
Disable "Invalid identification string" test as this prevents the code from working with devices that have a "9" instead of "3" or "5" as 4th character, but that work properly with the rest of the code.

See [https://github.com/esphome/issues/issues/6487](https://github.com/esphome/issues/issues/6487) for more details